### PR TITLE
for the var.resource_group.name replace it with the actual resource name

### DIFF
--- a/private_dns_zones.tf
+++ b/private_dns_zones.tf
@@ -2,14 +2,14 @@ resource "azurerm_private_dns_zone" "this" {
   for_each = var.private_dns != null ? var.private_dns : {}
 
   name                = each.value.zone_name
-  resource_group_name = each.value.resource_group_name == null ? var.resource_group.name : each.value.resource_group_name
+  resource_group_name = each.value.resource_group_name == null ? azurerm_resource_group.this.name : each.value.resource_group_name
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "this" {
   for_each = var.private_dns != null ? var.private_dns : {}
 
   name                  = each.value.zone_link_name == null ? "${each.key}_link" : each.value.zone_link_name
-  resource_group_name   = each.value.resource_group_name == null ? var.resource_group.name : each.value.resource_group_name
+  resource_group_name   = each.value.resource_group_name == null ? azurerm_resource_group.this.name : each.value.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.this[each.key].name
   virtual_network_id    = azurerm_virtual_network.this.id
 }


### PR DESCRIPTION
We got into an issue with deployment, that it was trying to deploy the resource before the creation of the resource group, this should fix that problem due to its referencing now the actual resource name and not the variable.