### PR TITLE
bug: dependency fix for vnet resource group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,8 +11,8 @@ resource "azurerm_resource_group" "this" {
 
 resource "azurerm_virtual_network" "this" {
   name                = var.vnet_name
-  location            = var.resource_group.location
-  resource_group_name = var.resource_group.name
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
   address_space       = var.vnet_address_space
   dns_servers         = var.vnet_dns_servers
   tags = merge(


### PR DESCRIPTION
noticed that my deploy fails due to not being able to deploy vnet in the resource group.
that was because the resource group did not existed yet.
the vnet was scoped on the variable and not on the resource resource_group

this fixes that